### PR TITLE
Add multiple diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Check e-book files for security and privacy issues.
 
-_Screener is currently in early development. Please consider contributing if you have the time and know-how!_
-
 ## Motivation
 
 E-books are great, but the common file formats have security and privacy issues. Most use web browser technologies like HTML, CSS, and JavaScript. Therefore, e-books are vulnerable to security and privacy issues that already exist on the web.
@@ -26,7 +24,7 @@ Screener requires [Python](https://www.python.org/about/gettingstarted/) (versio
 
 ### Installing
 
-Screen is available on [PyPI](https://pypi.org/project/screener/). To install, run:
+Screener is available on [PyPI](https://pypi.org/project/screener/). To install, run:
 
 ```bash
 pip install screener

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Screener"
-version = "0.3.2"
+version = "0.4.0"
 description = "Check e-book files for security and privacy issues."
 authors = ["Tom Kuson <mail@tjkuson.me>"]
 license = "LGPL-3.0-only"

--- a/screener/__main__.py
+++ b/screener/__main__.py
@@ -20,7 +20,7 @@ def init_argparse() -> ArgumentParser:
         "-v",
         "--version",
         action="version",
-        version=f"{parser.prog} version 0.3.2",
+        version=f"{parser.prog} version 0.4.0",
     )
     parser.add_argument("files", nargs="*")
     return parser

--- a/screener/__main__.py
+++ b/screener/__main__.py
@@ -4,6 +4,7 @@ import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
+from screener.checker import Checker
 from screener.diagnostic import (
     ExternalImageDiagnostic,
     JavaScriptDiagnostic,
@@ -32,21 +33,20 @@ def init_argparse() -> ArgumentParser:
 
 def check_file(
     file: Path,
-) -> JavaScriptDiagnostic | ExternalImageDiagnostic | ParseErrorDiagnostic | None:
+) -> Checker:
     """Check file."""
-    try:
-        extension = file.suffix
-        match extension:
-            case ".epub":
-                with EpubFileReader(file) as epub:
-                    return parse_epub(epub.file_path)
-            case ".azw3", ".mobi":
-                with KindleFileReader(file) as azw3:
-                    return parse_kindle(azw3.file_path)
-        return ParseErrorDiagnostic(file.name, f"unknown file extension: {extension}")
-    except (FileNotFoundError, IsADirectoryError) as exc:
-        print(f"{sys.argv[0]}: {file}: {exc.strerror}", file=sys.stderr)
-        return ParseErrorDiagnostic(file.name, exc.strerror)
+    extension = file.suffix
+    checker = Checker(file)
+    match extension:
+        case ".epub":
+            with EpubFileReader(file) as epub:
+                parse_epub(checker, epub.file_path)
+        case ".azw3", ".mobi":
+            with KindleFileReader(file) as azw3:
+                parse_kindle(checker, azw3.file_path)
+        case _:
+            raise ValueError(f"unsupported file extension: {extension}")
+    return checker
 
 
 def main() -> None:
@@ -59,16 +59,13 @@ def main() -> None:
         if file == "-":
             print("stdin not supported", file=sys.stderr)
             continue
-        diagnostic = check_file(Path(file))
-        match diagnostic:
-            case JavaScriptDiagnostic(file_path):
-                print(f"{file_path}: contains JavaScript", file=sys.stderr)
-            case ExternalImageDiagnostic(file_path):
-                print(f"{file_path}: contains external images", file=sys.stderr)
-            case ParseErrorDiagnostic(file_path, msg):
-                print(f"{file_path}: could not be parsed ({msg})", file=sys.stderr)
-            case None:
-                print(f"{file}: safe", file=sys.stderr)
+        checker = check_file(Path(file))
+        if checker.diagnostics:
+            for diagnostic in checker.diagnostics:
+                print(diagnostic)
+            sys.exit(1)
+        print(f"{checker.file_path.name} is safe")
+
     sys.exit()
 
 

--- a/screener/__main__.py
+++ b/screener/__main__.py
@@ -5,11 +5,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from screener.checker import Checker
-from screener.diagnostic import (
-    ExternalImageDiagnostic,
-    JavaScriptDiagnostic,
-    ParseErrorDiagnostic,
-)
 from screener.parser import parse_epub, parse_kindle
 from screener.reader import EpubFileReader, KindleFileReader
 
@@ -41,11 +36,12 @@ def check_file(
         case ".epub":
             with EpubFileReader(file) as epub:
                 parse_epub(checker, epub.file_path)
-        case ".azw3", ".mobi":
+        case ".azw3" | ".mobi":
             with KindleFileReader(file) as azw3:
                 parse_kindle(checker, azw3.file_path)
         case _:
-            raise ValueError(f"unsupported file extension: {extension}")
+            msg = f"unsupported file extension: {extension}"
+            raise ValueError(msg)
     return checker
 
 

--- a/screener/checker.py
+++ b/screener/checker.py
@@ -1,3 +1,4 @@
+"""Checker class for checking the data."""
 from dataclasses import dataclass, field
 from pathlib import Path
 

--- a/screener/checker.py
+++ b/screener/checker.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from screener.diagnostic import Diagnostic
+
+
+@dataclass
+class Checker:
+    """Checker class for checking the data."""
+
+    file_path: Path
+    diagnostics: list[Diagnostic] = field(default_factory=list)

--- a/screener/diagnostic.py
+++ b/screener/diagnostic.py
@@ -13,10 +13,16 @@ class Diagnostic:
 class JavaScriptDiagnostic(Diagnostic):
     """Diagnostic information about a file with JavaScript."""
 
+    def __str__(self) -> str:
+        return f"JavaScript found in {self.file_name}"
+
 
 @dataclass
 class ExternalImageDiagnostic(Diagnostic):
     """Diagnostic information about a file with external images."""
+
+    def __str__(self) -> str:
+        return f"External images found in {self.file_name}"
 
 
 @dataclass

--- a/screener/diagnostic.py
+++ b/screener/diagnostic.py
@@ -14,6 +14,7 @@ class JavaScriptDiagnostic(Diagnostic):
     """Diagnostic information about a file with JavaScript."""
 
     def __str__(self) -> str:
+        """Return a string representation of the diagnostic."""
         return f"JavaScript found in {self.file_name}"
 
 
@@ -22,6 +23,7 @@ class ExternalImageDiagnostic(Diagnostic):
     """Diagnostic information about a file with external images."""
 
     def __str__(self) -> str:
+        """Return a string representation of the diagnostic."""
         return f"External images found in {self.file_name}"
 
 

--- a/screener/parser/epub.py
+++ b/screener/parser/epub.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from ebooklib import ITEM_DOCUMENT
 
 from screener.checker import Checker
-from screener.diagnostic import ExternalImageDiagnostic, JavaScriptDiagnostic
 from screener.reader import EpubFileReader
 from screener.utils import (
     html_contains_images_with_external_sources,
@@ -24,9 +23,9 @@ def parse_epub(
     with EpubFileReader(path_to_epub) as epub:
         for item in epub.book.get_items_of_type(ITEM_DOCUMENT):
             content = item.get_content()
-            if diagnostics := html_contains_javascript(checker, content):
-                checker.diagnostics.extend(diagnostics)
-            if diagnostics := html_contains_images_with_external_sources(
+            if js := html_contains_javascript(checker, content):
+                checker.diagnostics.extend(js)
+            if external_images := html_contains_images_with_external_sources(
                 checker, content
             ):
-                checker.diagnostics.extend(diagnostics)
+                checker.diagnostics.extend(external_images)

--- a/screener/parser/kindle.py
+++ b/screener/parser/kindle.py
@@ -2,15 +2,10 @@
 
 from pathlib import Path
 
-from screener.diagnostic import (
-    ExternalImageDiagnostic,
-    JavaScriptDiagnostic,
-    ParseErrorDiagnostic,
-)
+from screener.checker import Checker
 from screener.reader.kindle import KindleFileReader
 
 from .epub import parse_epub
-from ..checker import Checker
 
 
 def parse_kindle(
@@ -23,11 +18,11 @@ def parse_kindle(
         raise ValueError(msg)
     with KindleFileReader(path_to_kindle) as kindle:
         if kindle.generated_translation is None:
-            return ParseErrorDiagnostic(
-                path_to_kindle.name, "failed to generate translation"
-            )
+            msg = "generated_translation cannot be None"
+            raise FileNotFoundError(msg)
         extension = Path(kindle.generated_translation).suffix
         match extension:
             case ".epub":
                 epub_translation = Path(kindle.generated_translation)
                 parse_epub(checker, epub_translation)
+                return

--- a/screener/parser/kindle.py
+++ b/screener/parser/kindle.py
@@ -10,11 +10,13 @@ from screener.diagnostic import (
 from screener.reader.kindle import KindleFileReader
 
 from .epub import parse_epub
+from ..checker import Checker
 
 
 def parse_kindle(
+    checker: Checker,
     path_to_kindle: Path | None,
-) -> JavaScriptDiagnostic | ExternalImageDiagnostic | ParseErrorDiagnostic | None:
+) -> None:
     """Parse kindle to check that it is safe."""
     if path_to_kindle is None:
         msg = "path_to_kindle cannot be None"
@@ -28,10 +30,4 @@ def parse_kindle(
         match extension:
             case ".epub":
                 epub_translation = Path(kindle.generated_translation)
-                if (diagnostic := parse_epub(epub_translation)) is not None:
-                    diagnostic.file_name = path_to_kindle.name
-                    return diagnostic
-                return None
-
-        # If failed to parse, assume it is unsafe.
-        return ParseErrorDiagnostic(path_to_kindle.name, "could not process file")
+                parse_epub(checker, epub_translation)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,7 @@ from screener.diagnostic import (
     JavaScriptDiagnostic,
 )
 from screener.parser import parse_epub, parse_kindle
+from screener.checker import Checker
 
 
 class TestParser:
@@ -19,27 +20,38 @@ class TestParser:
     def test_parse_epub(self) -> None:
         """Test epub file."""
         safe_epub_file = self.test_dir / "william-shakespeare_richard-ii.epub"
-        assert parse_epub(safe_epub_file) is None
+        safe_epub_file_checker = Checker(safe_epub_file)
+        parse_epub(safe_epub_file_checker, safe_epub_file)
+        assert safe_epub_file_checker.diagnostics == []
         unsafe_epub_file = (
             self.test_dir / "william-shakespeare_richard-ii_with-script-tags.epub"
         )
-        assert parse_epub(unsafe_epub_file) == JavaScriptDiagnostic(
-            unsafe_epub_file.name
-        )
+        unsafe_epub_file_checker = Checker(unsafe_epub_file)
+        parse_epub(unsafe_epub_file_checker, unsafe_epub_file)
+        assert unsafe_epub_file_checker.diagnostics == [
+            JavaScriptDiagnostic(unsafe_epub_file.name)
+        ]
 
     def test_parse_azw3(self: TestParser) -> None:
         """Test azw3 file."""
         safe_kindle_file = self.test_dir / "laozi_tao-te-ching_james-legge.azw3"
-        assert parse_kindle(safe_kindle_file) is None
+        safe_kindle_file_checker = Checker(safe_kindle_file)
+        parse_kindle(safe_kindle_file_checker, safe_kindle_file)
+        assert safe_kindle_file_checker.diagnostics == []
         unsafe_kindle_file = (
             self.test_dir / "laozi_tao-te-ching_james-legge_with-script-tags.azw3"
         )
-        assert parse_kindle(unsafe_kindle_file) == JavaScriptDiagnostic(
-            unsafe_kindle_file.name
-        )
+        unsafe_kindle_file_checker = Checker(unsafe_kindle_file)
+        parse_kindle(unsafe_kindle_file_checker, unsafe_kindle_file)
+        assert unsafe_kindle_file_checker.diagnostics == [
+            JavaScriptDiagnostic(unsafe_kindle_file.name),
+            JavaScriptDiagnostic(unsafe_kindle_file.name),
+        ]
 
     def test_parse_mobi(self: TestParser) -> None:
         """Test mobi file."""
         # mobi files don't support JavaScript, so they are always safe (wrt script tags)
         safe_kindle_file = self.test_dir / "edith-wharton_ethan-frome.mobi"
-        assert parse_kindle(safe_kindle_file) is None
+        safe_kindle_file_checker = Checker(safe_kindle_file)
+        parse_kindle(safe_kindle_file_checker, safe_kindle_file)
+        assert safe_kindle_file_checker.diagnostics == []

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from screener.checker import Checker
 from screener.diagnostic import (
     JavaScriptDiagnostic,
 )
 from screener.parser import parse_epub, parse_kindle
-from screener.checker import Checker
 
 
 class TestParser:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from screener.checker import Checker
 
 from screener.utils import (
     html_contains_images_with_external_sources,
@@ -15,32 +16,45 @@ class TestUtilFunctions:
 
     test_dir = Path(__file__).parent
 
-    def test_html_contains_javascript(self: TestUtilFunctions) -> None:
+    def test_html_contains_javascript(self) -> None:
         """Test html_contains_javascript function."""
-        # Check function returns False when there are no script tags
+        # Check function returns False when there are no script tags.
         safe_html = self.test_dir / "safe.html"
+        safe_html_checker = Checker(safe_html)
         with safe_html.open("rb") as file:
-            content: bytes = file.read()
-            assert not html_contains_javascript(content)
+            content = file.read()
+            assert html_contains_javascript(safe_html_checker, content) is None
 
-        # Check function returns True when there are script tags
+        # Check function returns True when there are script tags.
         html_with_script_tags = self.test_dir / "script_tags.html"
+        html_with_script_tags_checker = Checker(html_with_script_tags)
         with html_with_script_tags.open("rb") as file:
             content = file.read()
-            assert html_contains_javascript(content)
+            diagnostics = html_contains_javascript(
+                html_with_script_tags_checker, content
+            )
+            assert diagnostics is not None
+            assert len(diagnostics) == 1
 
-    def test_html_contains_images_with_external_sources(
-        self: TestUtilFunctions,
-    ) -> None:
+    def test_html_contains_images_with_external_sources(self) -> None:
         """Test html_contains_images_with_external_sources function."""
-        # Check function returns False when there are external images
+        # Check function returns False when there are external images.
         safe_html = self.test_dir / "safe_image.html"
+        safe_html_checker = Checker(safe_html)
         with safe_html.open("rb") as file:
             content = file.read()
-            assert not html_contains_images_with_external_sources(content)
+            assert (
+                html_contains_images_with_external_sources(safe_html_checker, content)
+                is None
+            )
 
-        # Check function returns True when there are external images
+        # Check function returns True when there are external images.
         html_with_external_image = self.test_dir / "unsafe_image.html"
+        html_with_external_image_checker = Checker(html_with_external_image)
         with html_with_external_image.open("rb") as file:
             content = file.read()
-            assert html_contains_images_with_external_sources(content)
+            diagnostics = html_contains_images_with_external_sources(
+                html_with_external_image_checker, content
+            )
+            assert diagnostics is not None
+            assert len(diagnostics) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from screener.checker import Checker
 
+from screener.checker import Checker
 from screener.utils import (
     html_contains_images_with_external_sources,
     html_contains_javascript,


### PR DESCRIPTION
Change to return multiple diagnostics per file to report multiple violations. Lays the groundwork for more useful error messages.

Bump to version `0.4.0`.